### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ CLProgressHUD
 
 CLProgressHUD is a colorful progress loading view for your iPhone or iPad APP.It works on any iOS version and is compatible with ARC projects. 
 
-###ScreenShots
+### ScreenShots
 <span><img src="./Screenshot/1.png" width="320px" heght="480px"></span>
 <span><img src="./Screenshot/2.png" width="320px" heght="480px"></span>
 <span><img src="./Screenshot/3.png" width="320px" heght="480px"></span>
 <span><img src="./Screenshot/4.png" width="320px" heght="480px"></span>
 
 
-###Usage
-####Example
+### Usage
+#### Example
 ```  
 CLProgressHUD *hud = [[CLProgressHUD alloc] initWithView:self.view];
 [self.view addSubview:hud];
@@ -20,13 +20,13 @@ hud.shape = CLProgressHUDShapeLinear;
 hud.type = CLProgressHUDTypeDarkForground;
 [hud showWithAnimation:NO duration:5];
 ```
-####Method
+#### Method
 ```
 - (void)showWithAnimation:(BOOL)animated;
 - (void)showWithAnimation:(BOOL)animated duration:(NSTimeInterval)duration;
 - (void)dismissWithAnimation:(BOOL)animated;
 ```
-####You Can Set up
+#### You Can Set up
 * text
 * CLProgressHUDType
 * CLProgressHUDShape


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
